### PR TITLE
Move to dedicated Fieldhand organisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,15 +57,15 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - First stable version of Fieldhand and its API for harvesting OAI-PMH repositories.
 
-[0.1.0]: https://github.com/altmetric/fieldhand/releases/tag/v0.1.0
-[0.2.0]: https://github.com/altmetric/fieldhand/releases/tag/v0.2.0
-[0.3.0]: https://github.com/altmetric/fieldhand/releases/tag/v0.3.0
-[0.3.1]: https://github.com/altmetric/fieldhand/releases/tag/v0.3.1
-[0.4.0]: https://github.com/altmetric/fieldhand/releases/tag/v0.4.0
-[0.5.0]: https://github.com/altmetric/fieldhand/releases/tag/v0.5.0
-[0.6.0]: https://github.com/altmetric/fieldhand/releases/tag/v0.6.0
-[0.7.0]: https://github.com/altmetric/fieldhand/releases/tag/v0.7.0
-[0.8.0]: https://github.com/altmetric/fieldhand/releases/tag/v0.8.0
-[0.9.0]: https://github.com/altmetric/fieldhand/releases/tag/v0.9.0
-[0.10.0]: https://github.com/altmetric/fieldhand/releases/tag/v0.10.0
-[0.11.0]: https://github.com/altmetric/fieldhand/releases/tag/v0.11.0
+[0.1.0]: https://github.com/fieldhand/fieldhand/releases/tag/v0.1.0
+[0.2.0]: https://github.com/fieldhand/fieldhand/releases/tag/v0.2.0
+[0.3.0]: https://github.com/fieldhand/fieldhand/releases/tag/v0.3.0
+[0.3.1]: https://github.com/fieldhand/fieldhand/releases/tag/v0.3.1
+[0.4.0]: https://github.com/fieldhand/fieldhand/releases/tag/v0.4.0
+[0.5.0]: https://github.com/fieldhand/fieldhand/releases/tag/v0.5.0
+[0.6.0]: https://github.com/fieldhand/fieldhand/releases/tag/v0.6.0
+[0.7.0]: https://github.com/fieldhand/fieldhand/releases/tag/v0.7.0
+[0.8.0]: https://github.com/fieldhand/fieldhand/releases/tag/v0.8.0
+[0.9.0]: https://github.com/fieldhand/fieldhand/releases/tag/v0.9.0
+[0.10.0]: https://github.com/fieldhand/fieldhand/releases/tag/v0.10.0
+[0.11.0]: https://github.com/fieldhand/fieldhand/releases/tag/v0.11.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2018 Altmetric LLP
+Copyright (c) 2017-2018 Altmetric and Paul Mucur
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fieldhand [![Build Status](https://travis-ci.org/altmetric/fieldhand.svg?branch=master)](https://travis-ci.org/altmetric/fieldhand)
+# Fieldhand [![Build Status](https://travis-ci.org/fieldhand/fieldhand.svg?branch=master)](https://travis-ci.org/fieldhand/fieldhand)
 
 A Ruby library for harvesting metadata from [OAI-PMH](https://www.openarchives.org/OAI/openarchivesprotocol.html) repositories.
 
@@ -635,6 +635,6 @@ This can be used to rescue all the following child error types.
 
 ## License
 
-Copyright © 2017-2018 Altmetric LLP
+Copyright © 2017-2018 Altmetric and Paul Mucur
 
 Distributed under the MIT License.

--- a/fieldhand.gemspec
+++ b/fieldhand.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.authors = ['Paul Mucur', 'Maciej Gajewski', 'Giovanni Derks', 'Abeer Salameh', 'Anna Klimas']
   s.email = 'support@altmetric.com'
-  s.homepage = 'https://github.com/altmetric/fieldhand'
+  s.homepage = 'https://github.com/fieldhand/fieldhand'
   s.files = %w[README.md LICENSE] + Dir['lib/**/*.rb']
   s.test_files = Dir['spec/**/*.rb']
 


### PR DESCRIPTION
Given the origins of this library, I would like to retain some ownership and maintenance responsibilities despite leaving Altmetric. To keep things neutral, move the source code to its own GitHub organisation.

This does not change the current owners of the published RubyGem but makes the ownership and licensing clearer.