### PR TITLE
Implement configurable retries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+dist: trusty
 rvm:
   - 1.8.7
   - 1.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.12.0] - 2019-09-24
+### Added
+- Added option to Repository for setting up configurable retries
+
 ## [0.11.0] - 2018-11-12
 ### Added
 - Support OAI repositories with namespace.
@@ -69,3 +73,4 @@ project adheres to [Semantic Versioning](http://semver.org/).
 [0.9.0]: https://github.com/fieldhand/fieldhand/releases/tag/v0.9.0
 [0.10.0]: https://github.com/fieldhand/fieldhand/releases/tag/v0.10.0
 [0.11.0]: https://github.com/fieldhand/fieldhand/releases/tag/v0.11.0
+[0.12.0]: https://github.com/fieldhand/fieldhand/releases/tag/v0.12.0

--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 A Ruby library for harvesting metadata from [OAI-PMH](https://www.openarchives.org/OAI/openarchivesprotocol.html) repositories.
 
-**Current version:** 0.11.0  
-**Supported Ruby versions:** 1.8.7, 1.9.2, 1.9.3, 2.0, 2.1, 2.2
+**Current version:** 0.12.0  
+**Supported Ruby versions:** 1.8.7, 1.9.2, 1.9.3, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6
 
 ## Installation
 
 ```
-gem install fieldhand -v '~> 0.11'
+gem install fieldhand -v '~> 0.12'
 ```
 
 Or, in your `Gemfile`:
 
 ```ruby
-gem 'fieldhand', '~> 0.11'
+gem 'fieldhand', '~> 0.12'
 ```
 
 ## Usage
@@ -116,14 +116,17 @@ Fieldhand::Repository.new('http://www.example.com/oai')
 Fieldhand::Repository.new(URI('http://www.example.com/oai'))
 Fieldhand::Repository.new('http://www.example.com/oai', :logger => Logger.new(STDOUT), :timeout => 10, :bearer_token => 'decafbad')
 Fieldhand::Repository.new('http://www.example.com/oai', :logger => Logger.new(STDOUT), :timeout => 10, :headers => { 'Custom header' => 'decafbad' })
+Fieldhand::Repository.new('http://www.example.com/oai', :logger => Logger.new(STDOUT), :retries => 5, :interval => 30)
 ```
 
 Return a new [`Repository`](#fieldhandrepository) instance accessible at the given `uri` (specified
 either as a [`URI`][URI] or
-something that can be coerced into a `URI` such as a `String`) with three options passed as a `Hash`:
+something that can be coerced into a `URI` such as a `String`) with options passed as a `Hash`:
 
 * `:logger`: a [`Logger`](http://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html)-compatible `logger`, defaults to a platform-specific null logger;
 * `:timeout`: a `Numeric` number of seconds to wait before timing out any HTTP requests, defaults to 60;
+* `:retries`: a `Numeric` number of times an HTTP request will be retried before raising an error, defaults to 0;
+* `:interval`: a `Numeric` number of seconds to wait before the next retry attempt, defaults to 10;
 * `:bearer_token`: a `String` bearer token to authorize any HTTP requests, defaults to `nil`.
 * `:headers`: a `Hash` containing custom HTTP headers, defaults to `{}`.
  

--- a/fieldhand.gemspec
+++ b/fieldhand.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'fieldhand'
-  s.version = '0.11.0'
+  s.version = '0.12.0'
   s.summary = 'An OAI-PMH harvester'
   s.description = <<-EOF
     A library to harvest metadata from OAI-PMH repositories.

--- a/lib/fieldhand/options.rb
+++ b/lib/fieldhand/options.rb
@@ -16,6 +16,8 @@ module Fieldhand
     # * :logger - A `Logger`-compatible class for logging the activity of the library, defaults to a platform-specific
     #             null logger
     # * :timeout - A `Numeric` number of seconds to wait for any HTTP requests, defaults to 60 seconds
+    # * :retries - A `Numeric` number of times a request is retried before erroring, defaults to 0
+    # * :interval - A `Numeric` number of seconds before an erroring request is retried, defaults to 10
     # * :bearer_token - A `String` bearer token to use when sending any HTTP requests, defaults to nil
     # * :headers - A `Hash` containing custom HTTP headers, defaults to {}.
     def initialize(logger_or_options = {})
@@ -30,6 +32,16 @@ module Fieldhand
     # Return the current logger.
     def logger
       options.fetch(:logger) { Logger.null }
+    end
+
+    # Return the current retries number.
+    def retries
+      options.fetch(:retries, 0)
+    end
+
+    # Return the current interval in seconds.
+    def interval
+      options.fetch(:interval, 10)
     end
 
     # Return the current bearer token.

--- a/lib/fieldhand/repository.rb
+++ b/lib/fieldhand/repository.rb
@@ -7,6 +7,7 @@ require 'fieldhand/list_records_parser'
 require 'fieldhand/list_sets_parser'
 require 'fieldhand/options'
 require 'fieldhand/paginator'
+require 'forwardable'
 require 'uri'
 
 module Fieldhand
@@ -14,23 +15,25 @@ module Fieldhand
   #
   # See https://www.openarchives.org/OAI/openarchivesprotocol.html
   class Repository
-    attr_reader :uri, :logger, :timeout, :headers
+    attr_reader :uri, :logger_or_options
+
+    extend Forwardable
+    def_delegators :paginator, :logger, :timeout, :headers
 
     # Return a new repository with the given base URL and an optional logger, timeout, bearer token and headers.
     #
     # The base URL can be passed as a `URI` or anything that can be parsed as a URI such as a string.
     #
+    # The retries and interval options are passed to the Paginator class.
+    #
     # For backward compatibility, the second argument can either be a logger or a hash containing
-    # a logger, timeout, bearer token and headers.
+    # a logger, timeout, retries, interval, bearer token and headers. Method calls are delgated to Paginator
     #
     # Defaults to using a null logger specific to this platform, a timeout of 60 seconds, no bearer token and no headers.
     def initialize(uri, logger_or_options = {})
       @uri = uri.is_a?(::URI) ? uri : URI(uri)
 
-      options = Options.new(logger_or_options)
-      @logger = options.logger
-      @timeout = options.timeout
-      @headers = options.headers
+      @logger_or_options = logger_or_options
     end
 
     # Send an Identify request to the repository and return an `Identify` response.
@@ -134,7 +137,7 @@ module Fieldhand
     private
 
     def paginator
-      @paginator ||= Paginator.new(uri, :logger => logger, :timeout => timeout, :headers => headers)
+      @paginator ||= Paginator.new(uri, logger_or_options)
     end
   end
 end

--- a/spec/fieldhand/options_spec.rb
+++ b/spec/fieldhand/options_spec.rb
@@ -56,6 +56,34 @@ module Fieldhand
       end
     end
 
+    describe '#retries' do
+      it 'defaults to 0' do
+        options = described_class.new({})
+
+        expect(options.retries).to eq(0)
+      end
+
+      it 'can be overridden by passing an option' do
+        options = described_class.new(:retries => 5)
+
+        expect(options.retries).to eq(5)
+      end
+    end
+
+    describe '#interval' do
+      it 'defaults to 10' do
+        options = described_class.new({})
+
+        expect(options.interval).to eq(10)
+      end
+
+      it 'can be overridden by passing an option' do
+        options = described_class.new(:interval => 5)
+
+        expect(options.interval).to eq(5)
+      end
+    end
+
     describe '#bearer_token' do
       it 'defaults to nil' do
         options = described_class.new({})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 require 'date'
 require 'webmock/rspec'
 
+FIXTURE_DIR = File.expand_path('../fixtures', __FILE__).freeze
+
 RSpec.configure do |config|
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.filter_run_when_matching :focus
@@ -21,9 +23,7 @@ RSpec.configure do |config|
   end
 
   def stub_oai_request(uri, fixture)
-    fixtures_dir = File.expand_path('../fixtures', __FILE__)
-
     stub_request(:get, uri).
-      to_return(:body => File.read(File.join(fixtures_dir, fixture)))
+      to_return(:body => File.read(File.join(FIXTURE_DIR, fixture)))
   end
 end


### PR DESCRIPTION
## Context

During a recent OAI import we had issues with non deterministic errors due to inconsistent API responses (500/503). 

Having the opportunity to configure retries will greatly improve the stability of the Import process, especially if they are containerised.